### PR TITLE
Simplify CI

### DIFF
--- a/.github/workflows/checks-basic.yml
+++ b/.github/workflows/checks-basic.yml
@@ -4,7 +4,8 @@
 name: 'Basic tests Mango CLI'
 
 on:
-  push:
+  #push:
+  workflow_dispatch:
 
 jobs:
   checks:

--- a/.github/workflows/checks-simple.yml
+++ b/.github/workflows/checks-simple.yml
@@ -1,0 +1,16 @@
+
+name: 'Simplified checks for Mango CLI'
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  checks:
+    name: Compile and test (basic)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Checks
+        run: docker build -f ci/image/new.Dockerfile .

--- a/.github/workflows/checks-stable.yml
+++ b/.github/workflows/checks-stable.yml
@@ -4,7 +4,7 @@
 name: 'Stable tests Mango CLI'
 
 on:
-  push:
+  #push:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/daily-base-image.yml
+++ b/.github/workflows/daily-base-image.yml
@@ -5,8 +5,8 @@
 name: 'Daily Mango base image'
 
 on:
-  schedule:
-    - cron: '0 3 * * 0'
+  #schedule:
+  #  - cron: '0 3 * * 0'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/dependency-checks.yml
+++ b/.github/workflows/dependency-checks.yml
@@ -4,8 +4,8 @@
 name: 'Check dependency status'
 
 on:
-  schedule:
-    - cron: '0 4 * * 0'
+  #schedule:
+  #  - cron: '0 4 * * 0'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release-simple.yml
+++ b/.github/workflows/release-simple.yml
@@ -1,0 +1,24 @@
+
+name: 'Publish Docker image for Mango CLI using simple image'
+
+on:
+  push:
+    branches:
+      - 'master'
+  workflow_dispatch:
+
+jobs:
+  checks:
+    name: Compile and test (basic)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Push to DockerHub
+        uses: docker/build-push-action@v1
+        with:
+          dockerfile: ci/image/new.Dockerfile
+          username: mangocode
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+          repository: mangocode/mango
+          tags: latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,9 +164,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
 name = "lock_api"
@@ -321,9 +321,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "regex"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
+checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fe99c6bd8b1cc636890bcc071842de909d902c81ac7dab53ba33c421ab8ffb"
+checksum = "b9505f307c872bab8eb46f77ae357c8eba1fdacead58ee5a850116b1d7f82883"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,6 +1,8 @@
 
 # Mango - continuous integration
 
+Note! Currently, a simplified, single-file Docker image is used. The smart caching etc was nice, but it was a hassle to manage multiple versions. 
+
 ## Principles
 
 * As much automatic validation as possible.

--- a/ci/simple.Dockerfile
+++ b/ci/simple.Dockerfile
@@ -5,6 +5,9 @@ ENV RUST_BACKTRACE=1
 
 RUN rustup component add rustfmt
 RUN rustup component add clippy
+RUN cargo install cargo-outdated
+RUN cargo install cargo-audit
+RUN cargo install cargo-deny
 RUN cargo install cargo-tree
 
 # Add the files needed to compile dependencies.
@@ -35,8 +38,13 @@ RUN cargo --offline clippy --workspace --all-targets --all-features -- -D warnin
 RUN cargo --offline fmt --all -- --check
 
 # Dependencies
-RUN cargo tree --workspace --all-features
-#TODO @mark:
+RUN cargo --offline tree --workspace --all-features > dep.tree
+#TODO @mark: deny warnings after `lock_api` is fixed
+RUN cat dep.tree && cargo --offline audit # --deny warnings
+RUN cat dep.tree && cargo --offline deny check advisories
+RUN cat dep.tree && cargo --offline deny check licenses
+RUN cat dep.tree && cargo --offline deny check bans
+RUN cat dep.tree && cargo --offline outdated --exit-code 1
 
 # Build release
 RUN cargo --offline build --workspace --release

--- a/ci/simple.Dockerfile
+++ b/ci/simple.Dockerfile
@@ -39,11 +39,12 @@ RUN cargo --offline fmt --all -- --check
 
 # Dependencies
 RUN cargo --offline tree --workspace --all-features > dep.tree
-#TODO @mark: deny warnings after `lock_api` is fixed
+#TODO @mark: deny warnings after https://github.com/anderslanglands/ustr/issues/17
 RUN cat dep.tree && cargo --offline audit # --deny warnings
 RUN cat dep.tree && cargo --offline deny check advisories
 RUN cat dep.tree && cargo --offline deny check licenses
-RUN cat dep.tree && cargo --offline deny check bans
+#TODO @mark: enable after https://github.com/anderslanglands/ustr/issues/17
+#RUN cat dep.tree && cargo --offline deny check bans
 RUN cat dep.tree && cargo --offline outdated --exit-code 1
 
 # Build release

--- a/ci/simple.Dockerfile
+++ b/ci/simple.Dockerfile
@@ -1,0 +1,25 @@
+
+FROM clux/muslrust:nightly-2021-04-24 AS build
+
+ENV RUST_BACKTRACE=1
+
+RUN rustup component add rustfmt
+RUN rustup component add clippy
+RUN cargo install cargo-tree
+
+# Add the files needed to compile dependencies.
+COPY ./Cargo.toml Cargo.lock ./
+RUN mkdir -p src && \
+    printf '\nfn main() {\n\tprintln!("placeholder for compiling dependencies")\n}\n' | tee src/main.rs
+
+# Build the dependencies, remove Cargo files so they have to be re-added.
+RUN cargo build --workspace --tests &&\
+    cargo build --workspace --release &&\
+    rm -f Cargo.lock Cargo.toml src/main.rs
+
+# Copy the actual code.
+COPY ./Cargo.toml ./Cargo.lock ./deny.toml ./rustfmt.toml ./
+
+# Build (for test)
+RUN touch -c src/main.rs &&\
+    cargo --offline build --workspace --tests

--- a/ci/simple.Dockerfile
+++ b/ci/simple.Dockerfile
@@ -19,7 +19,24 @@ RUN cargo build --workspace --tests &&\
 
 # Copy the actual code.
 COPY ./Cargo.toml ./Cargo.lock ./deny.toml ./rustfmt.toml ./
+COPY ./src ./src
 
 # Build (for test)
 RUN touch -c src/main.rs &&\
     cargo --offline build --workspace --tests
+
+# Test
+RUN cargo --offline test --workspace --all-targets --all-features
+
+# Lint
+RUN cargo --offline clippy --workspace --all-targets --all-features -- -D warnings
+
+# Style
+RUN cargo --offline fmt --all -- --check
+
+# Dependencies
+RUN cargo tree --workspace --all-features
+#TODO @mark:
+
+# Build release
+RUN cargo --offline build --workspace --release

--- a/deny.toml
+++ b/deny.toml
@@ -21,9 +21,11 @@ copyleft = "deny"
 # We want really high confidence when inferring licenses from text
 confidence-threshold = 0.95
 allow = [
-#    "Apache-2.0",
-#    "MIT",
-#    "BSD-2-Clause",
+    "Apache-2.0",
+    "MIT",
+    "BSD-2-Clause",
+    "BSD-2-Clause-Patent",
+    "CC0-1.0",
 ]
 
 exceptions = [


### PR DESCRIPTION
Use a simple, single-file Docker test setup. Might be temporary.

The old way had some nice advantages, like good caching, and separating tests into steps.

But it was getting very hard to maintain. So here is a much more simple solution.

The two are not quite equivalent in features, especially creating fewer artifacts. But the checks are pretty close.